### PR TITLE
Add option to receive all ArtDmx packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ const ArtNet = require('../src/artnet');
 
 const artnet = new Artnet({isController: true});
 
+/*
+   use getUniverse(0, false) to receive every data packet
+   regardless of whether they contain changes to previous
+   data or not
+*/
 const universe = artnet.getUniverse(0);
 
 universe.on('data', ({ data, changed }) => {

--- a/src/artnet.js
+++ b/src/artnet.js
@@ -66,9 +66,9 @@ module.exports = class Artnet extends EventEmitter {
         }
     }
 
-    getUniverse(universe) {
+    getUniverse(universe, changeOnly = true) {
         if (!this._universes[universe]) {
-            this._universes[universe] = new Universe(universe);
+            this._universes[universe] = new Universe(universe, changeOnly);
         }
         return this._universes[universe];
     }

--- a/src/universe.js
+++ b/src/universe.js
@@ -1,11 +1,12 @@
 const { EventEmitter } = require('events');
 
 module.exports = class Universe extends EventEmitter {
-    constructor(universe) {
+    constructor(universe, changeOnly) {
         super();
 
         this._data = new Uint8Array(512);
         this._universe = universe;
+        this._changeOnly = changeOnly;
     }
 
     get universe() {
@@ -30,7 +31,7 @@ module.exports = class Universe extends EventEmitter {
             }
         }
 
-        if (changed.length) {
+        if (!this.changeOnly || changed.length) {
             this.emit('data', { data, changed });
         }
     }


### PR DESCRIPTION
If no slots changed in the universe when it's received compared to the previous values, it won't be delivered to the application. This change allows creating universes that will deliver all ArtDmx packets, not just those that caused a change.